### PR TITLE
Fix several longstanding issues in ARL

### DIFF
--- a/src/main/java/vazkii/arl/AutoRegLib.java
+++ b/src/main/java/vazkii/arl/AutoRegLib.java
@@ -4,8 +4,6 @@
  */
 package vazkii.arl;
 
-import java.lang.invoke.MethodHandle;
-
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.Mod.Instance;

--- a/src/main/java/vazkii/arl/ClientProxy.java
+++ b/src/main/java/vazkii/arl/ClientProxy.java
@@ -4,28 +4,19 @@
  */
 package vazkii.arl;
 
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
-import vazkii.arl.util.ClientTicker;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.arl.util.DropInHandler;
-import vazkii.arl.util.ModelHandler;
 
+@SideOnly(Side.CLIENT)
 public class ClientProxy extends CommonProxy {
 
 	@Override
 	public void preInit(FMLPreInitializationEvent event) {
 		super.preInit(event);
-		MinecraftForge.EVENT_BUS.register(ModelHandler.class);
-		MinecraftForge.EVENT_BUS.register(ClientTicker.class);
 
 		DropInHandler.register();
-	}
-
-	@Override
-	public void init(FMLInitializationEvent event) {
-		super.init(event);
-		ModelHandler.init();
 	}
 	
 }

--- a/src/main/java/vazkii/arl/CommonProxy.java
+++ b/src/main/java/vazkii/arl/CommonProxy.java
@@ -4,19 +4,14 @@
  */
 package vazkii.arl;
 
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import vazkii.arl.network.NetworkHandler;
-import vazkii.arl.util.DropInHandler;
-import vazkii.arl.util.ProxyRegistry;
 
 public class CommonProxy {
 
-	public void preInit(FMLPreInitializationEvent event) { 
-		MinecraftForge.EVENT_BUS.register(ProxyRegistry.class);
-		
+	public void preInit(FMLPreInitializationEvent event) {
 		NetworkHandler.initARLMessages();
 	}
 

--- a/src/main/java/vazkii/arl/block/BlockFacing.java
+++ b/src/main/java/vazkii/arl/block/BlockFacing.java
@@ -11,7 +11,6 @@
 package vazkii.arl.block;
 
 import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyDirection;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
@@ -20,6 +19,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+
+import javax.annotation.Nonnull;
 
 public abstract class BlockFacing extends BlockModContainer {
 
@@ -65,6 +66,7 @@ public abstract class BlockFacing extends BlockModContainer {
 		}
 	}
 
+	@Nonnull
 	@Override
 	public IBlockState getStateFromMeta(int meta) {
 		EnumFacing enumfacing = EnumFacing.getFront(meta);
@@ -80,9 +82,10 @@ public abstract class BlockFacing extends BlockModContainer {
 		return state.getValue(FACING).getIndex();
 	}
 
+	@Nonnull
 	@Override
 	protected BlockStateContainer createBlockState() {
-		return new BlockStateContainer(this, new IProperty[] { FACING });
+		return new BlockStateContainer(this, FACING);
 	}
 
 }

--- a/src/main/java/vazkii/arl/block/BlockMetaVariants.java
+++ b/src/main/java/vazkii/arl/block/BlockMetaVariants.java
@@ -10,8 +10,6 @@
  */
 package vazkii.arl.block;
 
-import java.util.Locale;
-
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyEnum;
@@ -25,6 +23,10 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import vazkii.arl.interf.IVariantEnumHolder;
 
+import javax.annotation.Nonnull;
+import java.util.Locale;
+
+@SuppressWarnings("unchecked")
 public abstract class BlockMetaVariants<T extends Enum<T> & IStringSerializable> extends BlockMod {
 
 	public static Class temporaryVariantsEnum; // This is a massive hack, but such is life with constructors
@@ -48,6 +50,7 @@ public abstract class BlockMetaVariants<T extends Enum<T> & IStringSerializable>
 		return false;
 	}
 	
+	@Nonnull
 	@Override
 	public BlockStateContainer createBlockState() {
 		return new BlockStateContainer(this, temporaryVariantProp);
@@ -58,6 +61,7 @@ public abstract class BlockMetaVariants<T extends Enum<T> & IStringSerializable>
 		return ((Enum<T>) state.getValue(variantProp == null ? temporaryVariantProp : variantProp)).ordinal();
 	}
 
+	@Nonnull
 	@Override
 	public IBlockState getStateFromMeta(int meta) {
 		if(meta >= variantsEnum.getEnumConstants().length)
@@ -71,8 +75,9 @@ public abstract class BlockMetaVariants<T extends Enum<T> & IStringSerializable>
 		return getMetaFromState(state);
 	}
 
+	@Nonnull
 	@Override
-	public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player) {
+	public ItemStack getPickBlock(@Nonnull IBlockState state, RayTraceResult target, @Nonnull World world, @Nonnull BlockPos pos, EntityPlayer player) {
 		return new ItemStack(this, 1, getMetaFromState(world.getBlockState(pos)));
 	}
 
@@ -97,10 +102,11 @@ public abstract class BlockMetaVariants<T extends Enum<T> & IStringSerializable>
 		return variants;
 	}
 
-	public static interface EnumBase extends IStringSerializable {
+	public interface EnumBase extends IStringSerializable {
 
+		@Nonnull
 		@Override
-		public default String getName() {
+		default String getName() {
 			return ((Enum) this).name().toLowerCase(Locale.ENGLISH);
 		}
 

--- a/src/main/java/vazkii/arl/block/BlockMod.java
+++ b/src/main/java/vazkii/arl/block/BlockMod.java
@@ -13,13 +13,10 @@ package vazkii.arl.block;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
-import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.arl.interf.IModBlock;
 import vazkii.arl.item.ItemModBlock;
 import vazkii.arl.util.ProxyRegistry;
@@ -67,12 +64,6 @@ public abstract class BlockMod extends Block implements IModBlock {
 	@Override
 	public String[] getVariants() {
 		return variants;
-	}
-
-	@Override
-	@SideOnly(Side.CLIENT)
-	public ItemMeshDefinition getCustomMeshDefinition() {
-		return null;
 	}
 
 	@Override

--- a/src/main/java/vazkii/arl/block/BlockModContainer.java
+++ b/src/main/java/vazkii/arl/block/BlockModContainer.java
@@ -17,6 +17,8 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+import javax.annotation.Nonnull;
+
 public abstract class BlockModContainer extends BlockMod implements ITileEntityProvider {
 
 	public BlockModContainer(String name, Material materialIn, String... variants) {
@@ -25,7 +27,7 @@ public abstract class BlockModContainer extends BlockMod implements ITileEntityP
 	}
 
 	@Override
-	public void breakBlock(World worldIn, BlockPos pos, IBlockState state) {
+	public void breakBlock(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state) {
 		super.breakBlock(worldIn, pos, state);
 		worldIn.removeTileEntity(pos);
 	}
@@ -34,11 +36,11 @@ public abstract class BlockModContainer extends BlockMod implements ITileEntityP
 	public boolean eventReceived(IBlockState state, World worldIn, BlockPos pos, int eventID, int eventParam) {
 		super.eventReceived(state, worldIn, pos, eventID, eventParam);
 		TileEntity tileentity = worldIn.getTileEntity(pos);
-		return tileentity == null ? false : tileentity.receiveClientEvent(eventID, eventParam);
+		return tileentity != null && tileentity.receiveClientEvent(eventID, eventParam);
 	}
 
 	@Override
-	public TileEntity createNewTileEntity(World worldIn, int meta) {
+	public TileEntity createNewTileEntity(@Nonnull World worldIn, int meta) {
 		return null;
 	}
 }

--- a/src/main/java/vazkii/arl/block/BlockModDust.java
+++ b/src/main/java/vazkii/arl/block/BlockModDust.java
@@ -1,13 +1,8 @@
 package vazkii.arl.block;
 
-import java.util.Random;
-
-import javax.annotation.Nullable;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
@@ -29,6 +24,10 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.arl.block.BlockMetaVariants.EnumBase;
 import vazkii.arl.interf.IBlockColorProvider;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Random;
 
 public abstract class BlockModDust extends BlockMod implements IBlockColorProvider {
 
@@ -68,6 +67,7 @@ public abstract class BlockModDust extends BlockMod implements IBlockColorProvid
 		setSoundType(SoundType.STONE);
 	}
 
+	@Nonnull
 	@Override
 	public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
 		return WIRE_AABB[getAABBIndex(state.getActualState(source, pos))];
@@ -80,23 +80,24 @@ public abstract class BlockModDust extends BlockMod implements IBlockColorProvid
 		boolean south = state.getValue(SOUTH) != EnumAttachPosition.NONE;
 		boolean west = state.getValue(WEST) != EnumAttachPosition.NONE;
 
-		if(north || south && !north && !east && !west)
+		if(north || south && !east && !west)
 			i |= 1 << EnumFacing.NORTH.getHorizontalIndex();
 
-		if(east || west && !north && !east && !south)
+		if(east || west && !north && !south)
 			i |= 1 << EnumFacing.EAST.getHorizontalIndex();
 
-		if(south || north && !east && !south && !west)
+		if(south || north && !east && !west)
 			i |= 1 << EnumFacing.SOUTH.getHorizontalIndex();
 
-		if(west || east && !north && !south && !west)
+		if(west || east && !north && !south)
 			i |= 1 << EnumFacing.WEST.getHorizontalIndex();
 
 		return i;
 	}
 
+	@Nonnull
 	@Override
-	public IBlockState getActualState(IBlockState state, IBlockAccess worldIn, BlockPos pos) {
+	public IBlockState getActualState(@Nonnull IBlockState state, IBlockAccess worldIn, BlockPos pos) {
 		state = state.withProperty(WEST, getAttachPosition(worldIn, pos, EnumFacing.WEST));
 		state = state.withProperty(EAST, getAttachPosition(worldIn, pos, EnumFacing.EAST));
 		state = state.withProperty(NORTH, getAttachPosition(worldIn, pos, EnumFacing.NORTH));
@@ -131,7 +132,7 @@ public abstract class BlockModDust extends BlockMod implements IBlockColorProvid
 	}
 
 	@Override
-	public AxisAlignedBB getCollisionBoundingBox(IBlockState blockState, IBlockAccess worldIn, BlockPos pos) {
+	public AxisAlignedBB getCollisionBoundingBox(IBlockState blockState, @Nonnull IBlockAccess worldIn, @Nonnull BlockPos pos) {
 		return null;
 	}
 
@@ -146,7 +147,7 @@ public abstract class BlockModDust extends BlockMod implements IBlockColorProvid
 	}
 
 	@Override
-	public boolean canPlaceBlockAt(World worldIn, BlockPos pos) {
+	public boolean canPlaceBlockAt(World worldIn, @Nonnull BlockPos pos) {
 		return worldIn.getBlockState(pos.down()).isTopSolid() || worldIn.getBlockState(pos.down()).getBlock() == Blocks.GLOWSTONE;
 	}
 
@@ -167,11 +168,13 @@ public abstract class BlockModDust extends BlockMod implements IBlockColorProvid
 		return block == this;
 	}
 
+	@Nonnull
 	@Override
-	public ItemStack getItem(World worldIn, BlockPos pos, IBlockState state) {
+	public ItemStack getItem(World worldIn, BlockPos pos, @Nonnull IBlockState state) {
 		return new ItemStack(getItemDropped(state, worldIn.rand, 0));
 	}
 
+	@Nonnull
 	@Override
 	public IBlockState getStateFromMeta(int meta)  {
 		return getDefaultState();
@@ -182,13 +185,15 @@ public abstract class BlockModDust extends BlockMod implements IBlockColorProvid
 		return 0;
 	}
 
+	@Nonnull
 	@SideOnly(Side.CLIENT)
 	public BlockRenderLayer getBlockLayer() {
 		return BlockRenderLayer.CUTOUT;
 	}
 
+	@Nonnull
 	@Override
-	public IBlockState withRotation(IBlockState state, Rotation rot) {
+	public IBlockState withRotation(@Nonnull IBlockState state, Rotation rot) {
 		switch(rot) {
 		case CLOCKWISE_180:
 			return state.withProperty(NORTH, state.getValue(SOUTH)).withProperty(EAST, state.getValue(WEST)).withProperty(SOUTH, state.getValue(NORTH)).withProperty(WEST, state.getValue(EAST));
@@ -201,8 +206,9 @@ public abstract class BlockModDust extends BlockMod implements IBlockColorProvid
 		}
 	}
 
+	@Nonnull
 	@Override
-	public IBlockState withMirror(IBlockState state, Mirror mirrorIn) {
+	public IBlockState withMirror(@Nonnull IBlockState state, Mirror mirrorIn) {
 		switch(mirrorIn) {
 		case LEFT_RIGHT:
 			return state.withProperty(NORTH, state.getValue(SOUTH)).withProperty(SOUTH, state.getValue(NORTH));
@@ -213,16 +219,19 @@ public abstract class BlockModDust extends BlockMod implements IBlockColorProvid
 		}
 	}
 
+	@Nonnull
 	@Override
 	protected BlockStateContainer createBlockState() {
-		return new BlockStateContainer(this, new IProperty[] { NORTH, EAST, SOUTH, WEST });
+		return new BlockStateContainer(this, NORTH, EAST, SOUTH, WEST);
 	}
 
+	@Nonnull
 	@Override
 	public BlockFaceShape getBlockFaceShape(IBlockAccess p_193383_1_, IBlockState p_193383_2_, BlockPos p_193383_3_, EnumFacing p_193383_4_) {
 		return BlockFaceShape.UNDEFINED;
 	}
 
+	@Nonnull
 	@Override
 	public Item getItemDropped(IBlockState state, Random rand, int fortune) {
 		return Item.getItemFromBlock(this);
@@ -236,11 +245,12 @@ public abstract class BlockModDust extends BlockMod implements IBlockColorProvid
 	}
 
 	@Override
+	@SideOnly(Side.CLIENT)
 	public IItemColor getItemColor() {
 		return (stack, tint) -> 0xFFFFFF;
 	}
 
-	protected static enum EnumAttachPosition implements EnumBase {
+	protected enum EnumAttachPosition implements EnumBase {
 
 		UP,
 		SIDE,

--- a/src/main/java/vazkii/arl/block/BlockModFalling.java
+++ b/src/main/java/vazkii/arl/block/BlockModFalling.java
@@ -3,16 +3,15 @@ package vazkii.arl.block;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFalling;
 import net.minecraft.block.properties.IProperty;
-import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.arl.interf.IModBlock;
 import vazkii.arl.item.ItemModBlock;
 import vazkii.arl.util.ProxyRegistry;
+
+import javax.annotation.Nonnull;
 
 public abstract class BlockModFalling extends BlockFalling implements IModBlock {
 
@@ -30,8 +29,9 @@ public abstract class BlockModFalling extends BlockFalling implements IModBlock 
 			setUnlocalizedName(name);
 	}
 
+	@Nonnull
 	@Override
-	public Block setUnlocalizedName(String name) {
+	public Block setUnlocalizedName(@Nonnull String name) {
 		super.setUnlocalizedName(name);
 		setRegistryName(getPrefix() + name);
 		ProxyRegistry.register(this);
@@ -55,12 +55,6 @@ public abstract class BlockModFalling extends BlockFalling implements IModBlock 
 	@Override
 	public String[] getVariants() {
 		return variants;
-	}
-
-	@Override
-	@SideOnly(Side.CLIENT)
-	public ItemMeshDefinition getCustomMeshDefinition() {
-		return null;
 	}
 
 	@Override

--- a/src/main/java/vazkii/arl/block/BlockModSlab.java
+++ b/src/main/java/vazkii/arl/block/BlockModSlab.java
@@ -10,9 +10,6 @@
  */
 package vazkii.arl.block;
 
-import java.util.HashMap;
-import java.util.Random;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockSlab;
 import net.minecraft.block.material.Material;
@@ -20,11 +17,11 @@ import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
@@ -32,26 +29,29 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.arl.block.BlockMetaVariants.EnumBase;
 import vazkii.arl.interf.IModBlock;
 import vazkii.arl.item.ItemModBlockSlab;
 import vazkii.arl.recipe.RecipeHandler;
 import vazkii.arl.util.ProxyRegistry;
 
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Random;
+
 public abstract class BlockModSlab extends BlockSlab implements IModBlock {
 
 	static boolean tempDoubleSlab;
-	boolean doubleSlab;
+	protected boolean doubleSlab;
 	private final String[] variants;
 	private final String bareName;
 
 	public static final PropertyEnum prop = PropertyEnum.create("prop", DummyEnum.class);
 
-	public static HashMap<BlockModSlab, BlockModSlab> halfSlabs = new HashMap();
-	public static HashMap<BlockModSlab, BlockModSlab> fullSlabs = new HashMap();
+	public static HashMap<BlockModSlab, BlockModSlab> halfSlabs = new HashMap<>();
+	public static HashMap<BlockModSlab, BlockModSlab> fullSlabs = new HashMap<>();
 
+	@SuppressWarnings("unchecked")
 	public BlockModSlab(String name, Material materialIn, boolean doubleSlab) {
 		super(hacky(materialIn, doubleSlab));
 
@@ -68,7 +68,8 @@ public abstract class BlockModSlab extends BlockSlab implements IModBlock {
 			setDefaultState(blockState.getBaseState().withProperty(HALF, EnumBlockHalf.BOTTOM).withProperty(prop, DummyEnum.BLARG));
 		}
 
-		setCreativeTab(doubleSlab ? null : CreativeTabs.BUILDING_BLOCKS);
+		if (doubleSlab)
+			setCreativeTab(CreativeTabs.BUILDING_BLOCKS);
 	}
 
 	public static Material hacky(Material m, boolean doubleSlab) {
@@ -76,11 +77,19 @@ public abstract class BlockModSlab extends BlockSlab implements IModBlock {
 		return m;
 	}
 
+	public ItemBlock createItemBlock(ResourceLocation res) {
+		if (isDouble())
+			return new ItemModBlockSlab(this, res);
+		return null;
+	}
+
+	@Nonnull
 	@Override
 	public BlockStateContainer createBlockState() {
 		return tempDoubleSlab ? new BlockStateContainer(this, getVariantProp()) : new BlockStateContainer(this, HALF, getVariantProp());
 	}
 
+	@Nonnull
 	@Override
 	public IBlockState getStateFromMeta(int meta) {
 		if(doubleSlab)
@@ -103,26 +112,27 @@ public abstract class BlockModSlab extends BlockSlab implements IModBlock {
 		return halfSlabs.get(this);
 	}
 
+	@Nonnull
 	@Override
-	public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player) {
+	public ItemStack getPickBlock(@Nonnull IBlockState state, RayTraceResult target, @Nonnull World world, @Nonnull BlockPos pos, EntityPlayer player) {
 		return new ItemStack(getSingleBlock());
 	}
 
+	@Nonnull
 	@Override
 	public Item getItemDropped(IBlockState p_149650_1_, Random p_149650_2_, int p_149650_3_) {
 		return Item.getItemFromBlock(getSingleBlock());
 	}
 
 	@Override
-	public int quantityDropped(IBlockState state, int fortune, Random random) {
+	public int quantityDropped(IBlockState state, int fortune, @Nonnull Random random) {
 		return super.quantityDropped(state, fortune, random);
 	}
 
 	public void register() {
 		setRegistryName(getPrefix() + bareName);
 		ProxyRegistry.register(this);
-		if(!isDouble())
-			ProxyRegistry.register(new ItemModBlockSlab(this, new ResourceLocation(getPrefix() + bareName)));
+		ProxyRegistry.register(createItemBlock(getRegistryName()));
 	}
 
 	@Override
@@ -136,12 +146,6 @@ public abstract class BlockModSlab extends BlockSlab implements IModBlock {
 	}
 
 	@Override
-	@SideOnly(Side.CLIENT)
-	public ItemMeshDefinition getCustomMeshDefinition() {
-		return null;
-	}
-
-	@Override
 	public EnumRarity getBlockRarity(ItemStack stack) {
 		return EnumRarity.COMMON;
 	}
@@ -151,6 +155,7 @@ public abstract class BlockModSlab extends BlockSlab implements IModBlock {
 		return doubleSlab ? new IProperty[] { prop, HALF } : new IProperty[] { prop };
 	}
 
+	@Nonnull
 	@Override
 	public String getUnlocalizedName(int meta) {
 		return getUnlocalizedName();
@@ -167,7 +172,7 @@ public abstract class BlockModSlab extends BlockSlab implements IModBlock {
 	}
 
 	@Override
-	public boolean isSideSolid(IBlockState base_state, IBlockAccess world, BlockPos pos, EnumFacing side) {
+	public boolean isSideSolid(IBlockState base_state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, EnumFacing side) {
 		IBlockState state = getActualState(base_state, world, pos);
 		return isDouble()
 				|| (state.getValue(BlockSlab.HALF) == BlockSlab.EnumBlockHalf.TOP && side == EnumFacing.UP)
@@ -179,6 +184,7 @@ public abstract class BlockModSlab extends BlockSlab implements IModBlock {
 		return prop;
 	}
 
+	@Nonnull
 	@Override
 	public IProperty<?> getVariantProperty() {
 		return prop;
@@ -189,8 +195,9 @@ public abstract class BlockModSlab extends BlockSlab implements IModBlock {
 		return DummyEnum.class;
 	}
 
+	@Nonnull
 	@Override
-	public Comparable<?> getTypeForItem(ItemStack stack) {
+	public Comparable<?> getTypeForItem(@Nonnull ItemStack stack) {
 		return DummyEnum.BLARG;
 	}
 
@@ -208,7 +215,7 @@ public abstract class BlockModSlab extends BlockSlab implements IModBlock {
 				'B', ProxyRegistry.newStack(base, 1, meta));
 	}
 
-	public static enum DummyEnum implements EnumBase {
+	public enum DummyEnum implements EnumBase {
 		BLARG
 	}
 

--- a/src/main/java/vazkii/arl/block/BlockModStairs.java
+++ b/src/main/java/vazkii/arl/block/BlockModStairs.java
@@ -14,16 +14,16 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockStairs;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.item.EnumRarity;
+import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.arl.interf.IModBlock;
 import vazkii.arl.item.ItemModBlock;
 import vazkii.arl.recipe.RecipeHandler;
 import vazkii.arl.util.ProxyRegistry;
+
+import javax.annotation.Nonnull;
 
 public abstract class BlockModStairs extends BlockStairs implements IModBlock {
 
@@ -40,12 +40,18 @@ public abstract class BlockModStairs extends BlockStairs implements IModBlock {
 		useNeighborBrightness = true;
 	}
 
+
+	public ItemBlock createItemBlock(ResourceLocation res) {
+		return new ItemModBlock(this, res);
+	}
+
+	@Nonnull
 	@Override
-	public Block setUnlocalizedName(String name) {
+	public Block setUnlocalizedName(@Nonnull String name) {
 		super.setUnlocalizedName(name);
 		setRegistryName(getPrefix() + name);
 		ProxyRegistry.register(this);
-		ProxyRegistry.register(new ItemModBlock(this, new ResourceLocation(getPrefix() + name)));
+		ProxyRegistry.register(createItemBlock(getRegistryName()));
 		return this;
 	}
 
@@ -57,12 +63,6 @@ public abstract class BlockModStairs extends BlockStairs implements IModBlock {
 	@Override
 	public String[] getVariants() {
 		return variants;
-	}
-
-	@Override
-	@SideOnly(Side.CLIENT)
-	public ItemMeshDefinition getCustomMeshDefinition() {
-		return null;
 	}
 
 	@Override

--- a/src/main/java/vazkii/arl/block/tile/TileMod.java
+++ b/src/main/java/vazkii/arl/block/tile/TileMod.java
@@ -13,20 +13,22 @@ package vazkii.arl.block.tile;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
-import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import vazkii.arl.util.VanillaPacketDispatcher;
 
+import javax.annotation.Nonnull;
+
 public abstract class TileMod extends TileEntity {
 
 	@Override
-	public boolean shouldRefresh(World world, BlockPos pos, IBlockState oldState, IBlockState newState) {
+	public boolean shouldRefresh(World world, BlockPos pos, @Nonnull IBlockState oldState, @Nonnull IBlockState newState) {
 		return oldState.getBlock() != newState.getBlock();
 	}
 
+	@Nonnull
 	@Override
 	public NBTTagCompound writeToNBT(NBTTagCompound par1nbtTagCompound) {
 		NBTTagCompound nbt = super.writeToNBT(par1nbtTagCompound);
@@ -54,10 +56,11 @@ public abstract class TileMod extends TileEntity {
 		VanillaPacketDispatcher.dispatchTEToNearbyPlayers(this);
 	}
 
+	@Nonnull
 	@Override
-    public NBTTagCompound getUpdateTag()  {
-        return writeToNBT(new NBTTagCompound());
-    }
+	public NBTTagCompound getUpdateTag()  {
+		return writeToNBT(new NBTTagCompound());
+	}
 	
 	@Override
 	public SPacketUpdateTileEntity getUpdatePacket() {

--- a/src/main/java/vazkii/arl/block/tile/TileSimpleInventory.java
+++ b/src/main/java/vazkii/arl/block/tile/TileSimpleInventory.java
@@ -23,6 +23,8 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.wrapper.SidedInvWrapper;
 
+import javax.annotation.Nonnull;
+
 public abstract class TileSimpleInventory extends TileMod implements ISidedInventory {
 
 	protected NonNullList<ItemStack> inventorySlots = NonNullList.withSize(getSizeInventory(), ItemStack.EMPTY);
@@ -64,11 +66,13 @@ public abstract class TileSimpleInventory extends TileMod implements ISidedInven
 		return true;
 	}
 	
+	@Nonnull
 	@Override
 	public ItemStack getStackInSlot(int i) {
 		return inventorySlots.get(i);
 	}
 
+	@Nonnull
 	@Override
 	public ItemStack decrStackSize(int i, int j) {
 		if (!inventorySlots.get(i).isEmpty()) {
@@ -93,6 +97,7 @@ public abstract class TileSimpleInventory extends TileMod implements ISidedInven
 		return ItemStack.EMPTY;
 	}
 
+	@Nonnull
 	@Override
 	public ItemStack removeStackFromSlot(int i) {
 		ItemStack stack = getStackInSlot(i);
@@ -102,7 +107,7 @@ public abstract class TileSimpleInventory extends TileMod implements ISidedInven
 	}
 
 	@Override
-	public void setInventorySlotContents(int i, ItemStack itemstack) {
+	public void setInventorySlotContents(int i, @Nonnull ItemStack itemstack) {
 		inventorySlots.set(i, itemstack);
 		inventoryChanged(i);
 	}
@@ -124,25 +129,25 @@ public abstract class TileSimpleInventory extends TileMod implements ISidedInven
 	}
 
 	@Override
-	public boolean isUsableByPlayer(EntityPlayer entityplayer) {
+	public boolean isUsableByPlayer(@Nonnull EntityPlayer entityplayer) {
 		return getWorld().getTileEntity(getPos()) == this && entityplayer.getDistanceSq(pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D) <= 64;
 	}
 	
 	@Override
-	public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
+	public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing facing) {
 		return capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY;
 	}
 	
 	@Override
-	public <T> T getCapability(Capability<T> capability, EnumFacing facing) {
+	public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing facing) {
 		if(capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
-			return (T) new SidedInvWrapper(this, facing);
+			return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(new SidedInvWrapper(this, facing));
 		
 		return null;
 	}
 
 	@Override
-	public boolean isItemValidForSlot(int i, ItemStack itemstack) {
+	public boolean isItemValidForSlot(int i, @Nonnull ItemStack itemstack) {
 		return true;
 	}
 
@@ -152,12 +157,12 @@ public abstract class TileSimpleInventory extends TileMod implements ISidedInven
 	}
 
 	@Override
-	public void openInventory(EntityPlayer player) {
+	public void openInventory(@Nonnull EntityPlayer player) {
 		// NO-OP
 	}
 
 	@Override
-	public void closeInventory(EntityPlayer player) {
+	public void closeInventory(@Nonnull EntityPlayer player) {
 		// NO-OP
 	}
 
@@ -181,11 +186,13 @@ public abstract class TileSimpleInventory extends TileMod implements ISidedInven
 		inventorySlots = NonNullList.withSize(getSizeInventory(), ItemStack.EMPTY);
 	}
 
+	@Nonnull
 	@Override
 	public ITextComponent getDisplayName() {
 		return new TextComponentTranslation(getName());
 	}
 	
+	@Nonnull
 	@Override
 	public String getName() {
 		if(name == null)
@@ -202,17 +209,18 @@ public abstract class TileSimpleInventory extends TileMod implements ISidedInven
 	}
 
 	@Override
-	public boolean canExtractItem(int index, ItemStack stack, EnumFacing direction) {
+	public boolean canExtractItem(int index, @Nonnull ItemStack stack, @Nonnull EnumFacing direction) {
 		return isAutomationEnabled();
 	}
 
 	@Override
-	public boolean canInsertItem(int index, ItemStack itemStackIn, EnumFacing direction) {
+	public boolean canInsertItem(int index, @Nonnull ItemStack itemStackIn, @Nonnull EnumFacing direction) {
 		return isAutomationEnabled();
 	}
 
+	@Nonnull
 	@Override
-	public int[] getSlotsForFace(EnumFacing side) {
+	public int[] getSlotsForFace(@Nonnull EnumFacing side) {
 		if(isAutomationEnabled()) {
 			int[] slots = new int[getSizeInventory()];
 			for(int i = 0; i < slots.length; i++)

--- a/src/main/java/vazkii/arl/client/AtlasSpriteHelper.java
+++ b/src/main/java/vazkii/arl/client/AtlasSpriteHelper.java
@@ -28,22 +28,22 @@ public final class AtlasSpriteHelper {
 	 * Renders a sprite from the spritesheet with depth, like a "builtin/generated" item model.
 	 * Adapted from ItemRenderer.renderItemIn2D, 1.7.10
 	 */
-	public static void renderIconThicc(Tessellator tess, float p_78439_1_, float p_78439_2_, float p_78439_3_, float p_78439_4_, int width, int height, float thickness) {
+	public static void renderIconThicc(Tessellator tess, float maxU, float maxV, float minU, float minV, int width, int height, float thickness) {
 		BufferBuilder wr = tess.getBuffer();
 		wr.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_NORMAL);
-		wr.pos(0.0D, 0.0D, 0.0D).tex(p_78439_1_, p_78439_4_).normal(0, 0, 1).endVertex();
-		wr.pos(1.0D, 0.0D, 0.0D).tex(p_78439_3_, p_78439_4_).normal(0, 0, 1).endVertex();
-		wr.pos(1.0D, 1.0D, 0.0D).tex(p_78439_3_, p_78439_2_).normal(0, 0, 1).endVertex();
-		wr.pos(0.0D, 1.0D, 0.0D).tex(p_78439_1_, p_78439_2_).normal(0, 0, 1).endVertex();
+		wr.pos(0.0D, 0.0D, 0.0D).tex(maxU, minV).normal(0, 0, 1).endVertex();
+		wr.pos(1.0D, 0.0D, 0.0D).tex(minU, minV).normal(0, 0, 1).endVertex();
+		wr.pos(1.0D, 1.0D, 0.0D).tex(minU, maxV).normal(0, 0, 1).endVertex();
+		wr.pos(0.0D, 1.0D, 0.0D).tex(maxU, maxV).normal(0, 0, 1).endVertex();
 		tess.draw();
 		wr.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_NORMAL);
-		wr.pos(0.0D, 1.0D, 0.0F - thickness).tex(p_78439_1_, p_78439_2_).normal(0, 0, -1).endVertex();
-		wr.pos(1.0D, 1.0D, 0.0F - thickness).tex(p_78439_3_, p_78439_2_).normal(0, 0, -1).endVertex();
-		wr.pos(1.0D, 0.0D, 0.0F - thickness).tex(p_78439_3_, p_78439_4_).normal(0, 0, -1).endVertex();
-		wr.pos(0.0D, 0.0D, 0.0F - thickness).tex(p_78439_1_, p_78439_4_).normal(0, 0, -1).endVertex();
+		wr.pos(0.0D, 1.0D, 0.0F - thickness).tex(maxU, maxV).normal(0, 0, -1).endVertex();
+		wr.pos(1.0D, 1.0D, 0.0F - thickness).tex(minU, maxV).normal(0, 0, -1).endVertex();
+		wr.pos(1.0D, 0.0D, 0.0F - thickness).tex(minU, minV).normal(0, 0, -1).endVertex();
+		wr.pos(0.0D, 0.0D, 0.0F - thickness).tex(maxU, minV).normal(0, 0, -1).endVertex();
 		tess.draw();
-		float f5 = 0.5F * (p_78439_1_ - p_78439_3_) / width;
-		float f6 = 0.5F * (p_78439_4_ - p_78439_2_) / height;
+		float f5 = 0.5F * (maxU - minU) / width;
+		float f6 = 0.5F * (minV - maxV) / height;
 		wr.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_NORMAL);
 		int k;
 		float f7;
@@ -52,11 +52,11 @@ public final class AtlasSpriteHelper {
 		for (k = 0; k < width; ++k)
 		{
 			f7 = (float)k / (float)width;
-			f8 = p_78439_1_ + (p_78439_3_ - p_78439_1_) * f7 - f5;
-			wr.pos(f7, 0.0D, 0.0F - thickness).tex(f8, p_78439_4_).normal(-1, 0, 0).endVertex();
-			wr.pos(f7, 0.0D, 0.0D).tex(f8, p_78439_4_).normal(-1, 0, 0).endVertex();
-			wr.pos(f7, 1.0D, 0.0D).tex(f8, p_78439_2_).normal(-1, 0, 0).endVertex();
-			wr.pos(f7, 1.0D, 0.0F - thickness).tex(f8, p_78439_2_).normal(-1, 0, 0).endVertex();
+			f8 = maxU + (minU - maxU) * f7 - f5;
+			wr.pos(f7, 0.0D, 0.0F - thickness).tex(f8, minV).normal(-1, 0, 0).endVertex();
+			wr.pos(f7, 0.0D, 0.0D).tex(f8, minV).normal(-1, 0, 0).endVertex();
+			wr.pos(f7, 1.0D, 0.0D).tex(f8, maxV).normal(-1, 0, 0).endVertex();
+			wr.pos(f7, 1.0D, 0.0F - thickness).tex(f8, maxV).normal(-1, 0, 0).endVertex();
 		}
 
 		tess.draw();
@@ -66,12 +66,12 @@ public final class AtlasSpriteHelper {
 		for (k = 0; k < width; ++k)
 		{
 			f7 = (float)k / (float)width;
-			f8 = p_78439_1_ + (p_78439_3_ - p_78439_1_) * f7 - f5;
+			f8 = maxU + (minU - maxU) * f7 - f5;
 			f9 = f7 + 1.0F / width;
-			wr.pos(f9, 1.0D, 0.0F - thickness).tex(f8, p_78439_2_).normal(1, 0, 0).endVertex();
-			wr.pos(f9, 1.0D, 0.0D).tex(f8, p_78439_2_).normal(1, 0, 0).endVertex();
-			wr.pos(f9, 0.0D, 0.0D).tex(f8, p_78439_4_).normal(1, 0, 0).endVertex();
-			wr.pos(f9, 0.0D, 0.0F - thickness).tex(f8, p_78439_4_).normal(1, 0, 0).endVertex();
+			wr.pos(f9, 1.0D, 0.0F - thickness).tex(f8, maxV).normal(1, 0, 0).endVertex();
+			wr.pos(f9, 1.0D, 0.0D).tex(f8, maxV).normal(1, 0, 0).endVertex();
+			wr.pos(f9, 0.0D, 0.0D).tex(f8, minV).normal(1, 0, 0).endVertex();
+			wr.pos(f9, 0.0D, 0.0F - thickness).tex(f8, minV).normal(1, 0, 0).endVertex();
 		}
 
 		tess.draw();
@@ -80,12 +80,12 @@ public final class AtlasSpriteHelper {
 		for (k = 0; k < height; ++k)
 		{
 			f7 = (float)k / (float)height;
-			f8 = p_78439_4_ + (p_78439_2_ - p_78439_4_) * f7 - f6;
+			f8 = minV + (maxV - minV) * f7 - f6;
 			f9 = f7 + 1.0F / height;
-			wr.pos(0.0D, f9, 0.0D).tex(p_78439_1_, f8).normal(0, 1, 0).endVertex();
-			wr.pos(1.0D, f9, 0.0D).tex(p_78439_3_, f8).normal(0, 1, 0).endVertex();
-			wr.pos(1.0D, f9, 0.0F - thickness).tex(p_78439_3_, f8).normal(0, 1, 0).endVertex();
-			wr.pos(0.0D, f9, 0.0F - thickness).tex(p_78439_1_, f8).normal(0, 1, 0).endVertex();
+			wr.pos(0.0D, f9, 0.0D).tex(maxU, f8).normal(0, 1, 0).endVertex();
+			wr.pos(1.0D, f9, 0.0D).tex(minU, f8).normal(0, 1, 0).endVertex();
+			wr.pos(1.0D, f9, 0.0F - thickness).tex(minU, f8).normal(0, 1, 0).endVertex();
+			wr.pos(0.0D, f9, 0.0F - thickness).tex(maxU, f8).normal(0, 1, 0).endVertex();
 		}
 
 		tess.draw();
@@ -94,11 +94,11 @@ public final class AtlasSpriteHelper {
 		for (k = 0; k < height; ++k)
 		{
 			f7 = (float)k / (float)height;
-			f8 = p_78439_4_ + (p_78439_2_ - p_78439_4_) * f7 - f6;
-			wr.pos(1.0D, f7, 0.0D).tex(p_78439_3_, f8).normal(0, -1, 0).endVertex();
-			wr.pos(0.0D, f7, 0.0D).tex(p_78439_1_, f8).normal(0, -1, 0).endVertex();
-			wr.pos(0.0D, f7, 0.0F - thickness).tex(p_78439_1_, f8).normal(0, -1, 0).endVertex();
-			wr.pos(1.0D, f7, 0.0F - thickness).tex(p_78439_3_, f8).normal(0, -1, 0).endVertex();
+			f8 = minV + (maxV - minV) * f7 - f6;
+			wr.pos(1.0D, f7, 0.0D).tex(minU, f8).normal(0, -1, 0).endVertex();
+			wr.pos(0.0D, f7, 0.0D).tex(maxU, f8).normal(0, -1, 0).endVertex();
+			wr.pos(0.0D, f7, 0.0F - thickness).tex(maxU, f8).normal(0, -1, 0).endVertex();
+			wr.pos(1.0D, f7, 0.0F - thickness).tex(minU, f8).normal(0, -1, 0).endVertex();
 		}
 
 		tess.draw();

--- a/src/main/java/vazkii/arl/client/RetexturedModel.java
+++ b/src/main/java/vazkii/arl/client/RetexturedModel.java
@@ -1,9 +1,6 @@
 package vazkii.arl.client;
 
-import java.util.List;
-
 import com.google.common.collect.ImmutableMap;
-
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.IBakedModel;
@@ -14,6 +11,9 @@ import net.minecraftforge.client.model.IModel;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.common.property.IExtendedBlockState;
 import vazkii.arl.interf.IStateMapperProvider;
+
+import javax.annotation.Nonnull;
+import java.util.List;
 
 public class RetexturedModel extends BakedModelWrapper<IBakedModel> {
 
@@ -27,6 +27,7 @@ public class RetexturedModel extends BakedModelWrapper<IBakedModel> {
 		this.textureKey = textureKey;
 	}
 
+	@Nonnull
 	@Override
 	public List<BakedQuad> getQuads(IBlockState state, EnumFacing side, long rand) {
 		IBakedModel bakedModel = this.originalModel;

--- a/src/main/java/vazkii/arl/container/ContainerBasic.java
+++ b/src/main/java/vazkii/arl/container/ContainerBasic.java
@@ -6,7 +6,8 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
+
+import javax.annotation.Nonnull;
 
 public abstract class ContainerBasic<T extends IInventory> extends Container {
 
@@ -28,10 +29,11 @@ public abstract class ContainerBasic<T extends IInventory> extends Container {
 	public abstract int addSlots(); 
 
 	@Override
-	public boolean canInteractWith(EntityPlayer playerIn) {
+	public boolean canInteractWith(@Nonnull EntityPlayer playerIn) {
 		return tile.isUsableByPlayer(playerIn);
 	}
 
+	@Nonnull
 	@Override
 	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index) {
 		ItemStack itemstack = ItemStack.EMPTY;

--- a/src/main/java/vazkii/arl/interf/IBlockColorProvider.java
+++ b/src/main/java/vazkii/arl/interf/IBlockColorProvider.java
@@ -17,6 +17,6 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 public interface IBlockColorProvider extends IItemColorProvider {
 
 	@SideOnly(Side.CLIENT)
-	public IBlockColor getBlockColor();
+	IBlockColor getBlockColor();
 
 }

--- a/src/main/java/vazkii/arl/interf/IDropInItem.java
+++ b/src/main/java/vazkii/arl/interf/IDropInItem.java
@@ -1,8 +1,5 @@
 package vazkii.arl.interf;
 
-import java.util.Arrays;
-import java.util.List;
-
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -11,18 +8,21 @@ import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import java.util.Collections;
+import java.util.List;
+
 public interface IDropInItem {
 
 	@CapabilityInject(IDropInItem.class)
-	public static Capability<IDropInItem> DROP_IN_CAPABILITY = null;
+	Capability<IDropInItem> DROP_IN_CAPABILITY = null;
 
-	public boolean canDropItemIn(EntityPlayer player, ItemStack stack, ItemStack incoming);
+	boolean canDropItemIn(EntityPlayer player, ItemStack stack, ItemStack incoming);
 
-	public ItemStack dropItemIn(EntityPlayer player, ItemStack stack, ItemStack incoming);
+	ItemStack dropItemIn(EntityPlayer player, ItemStack stack, ItemStack incoming);
 
 	@SideOnly(Side.CLIENT)
-	public default List<String> getDropInTooltip(ItemStack stack) {
-		return Arrays.asList(I18n.format("arl.misc.rightClickAdd"));
+	default List<String> getDropInTooltip(ItemStack stack) {
+		return Collections.singletonList(I18n.format("arl.misc.rightClickAdd"));
 	}
 
 }

--- a/src/main/java/vazkii/arl/interf/IExtraVariantHolder.java
+++ b/src/main/java/vazkii/arl/interf/IExtraVariantHolder.java
@@ -12,6 +12,6 @@ package vazkii.arl.interf;
 
 public interface IExtraVariantHolder extends IVariantHolder {
 
-	public String[] getExtraVariants();
+	String[] getExtraVariants();
 
 }

--- a/src/main/java/vazkii/arl/interf/IItemColorProvider.java
+++ b/src/main/java/vazkii/arl/interf/IItemColorProvider.java
@@ -17,6 +17,6 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 public interface IItemColorProvider {
 
 	@SideOnly(Side.CLIENT)
-	public IItemColor getItemColor();
+	IItemColor getItemColor();
 
 }

--- a/src/main/java/vazkii/arl/interf/IModBlock.java
+++ b/src/main/java/vazkii/arl/interf/IModBlock.java
@@ -19,21 +19,21 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 public interface IModBlock extends IVariantHolder, IVariantEnumHolder, IStateMapperProvider {
 
-	public String getBareName();
+	String getBareName();
 
-	public IProperty getVariantProp();
+	IProperty getVariantProp();
 
-	public IProperty[] getIgnoredProperties();
+	IProperty[] getIgnoredProperties();
 
-	public EnumRarity getBlockRarity(ItemStack stack);
+	EnumRarity getBlockRarity(ItemStack stack);
 
-	public default boolean shouldDisplayVariant(int variant) {
+	default boolean shouldDisplayVariant(int variant) {
 		return true;
 	}
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public default IStateMapper getStateMapper() {
+	default IStateMapper getStateMapper() {
 		return null;
 	}
 

--- a/src/main/java/vazkii/arl/interf/IRecipeGrouped.java
+++ b/src/main/java/vazkii/arl/interf/IRecipeGrouped.java
@@ -2,6 +2,6 @@ package vazkii.arl.interf;
 
 public interface IRecipeGrouped {
 
-	public String getRecipeGroup();
+	String getRecipeGroup();
 	
 }

--- a/src/main/java/vazkii/arl/interf/IStateMapperProvider.java
+++ b/src/main/java/vazkii/arl/interf/IStateMapperProvider.java
@@ -17,9 +17,9 @@ import vazkii.arl.block.property.PropertyString;
 
 public interface IStateMapperProvider {
 
-	public static final PropertyString TEXTURE = new PropertyString("texture");
+	PropertyString TEXTURE = new PropertyString("texture");
 	
 	@SideOnly(Side.CLIENT)
-	public IStateMapper getStateMapper();
+	IStateMapper getStateMapper();
 
 }

--- a/src/main/java/vazkii/arl/interf/IVariantEnumHolder.java
+++ b/src/main/java/vazkii/arl/interf/IVariantEnumHolder.java
@@ -14,8 +14,8 @@ import net.minecraft.util.IStringSerializable;
 
 public interface IVariantEnumHolder<T extends Enum<T> & IStringSerializable> {
 
-	public static final String HEADER = "variant";
+	String HEADER = "variant";
 
-	public Class<T> getVariantEnum();
+	Class<T> getVariantEnum();
 
 }

--- a/src/main/java/vazkii/arl/interf/IVariantHolder.java
+++ b/src/main/java/vazkii/arl/interf/IVariantHolder.java
@@ -16,18 +16,20 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 public interface IVariantHolder {
 
-	public String[] getVariants();
+	String[] getVariants();
 
 	@SideOnly(Side.CLIENT)
-	public ItemMeshDefinition getCustomMeshDefinition();
+	default ItemMeshDefinition getCustomMeshDefinition() {
+		return null;
+	}
 
-	public default String getUniqueModel() {
+	default String getUniqueModel() {
 		return null;
 	}
 	
-	public String getModNamespace();
+	String getModNamespace();
 
-	public default String getPrefix() {
+	default String getPrefix() {
 		return getModNamespace() + ":";
 	}
 }

--- a/src/main/java/vazkii/arl/item/ItemMod.java
+++ b/src/main/java/vazkii/arl/item/ItemMod.java
@@ -10,10 +10,6 @@
  */
 package vazkii.arl.item;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -25,9 +21,13 @@ import vazkii.arl.interf.IVariantHolder;
 import vazkii.arl.util.ProxyRegistry;
 import vazkii.arl.util.TooltipHandler;
 
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
 public abstract class ItemMod extends Item implements IVariantHolder {
 
-	public static final List<IVariantHolder> variantHolders = new ArrayList();
+	public static final List<IVariantHolder> variantHolders = new ArrayList<>();
 
 	private final String[] variants;
 	private final String bareName;
@@ -42,11 +42,11 @@ public abstract class ItemMod extends Item implements IVariantHolder {
 
 		bareName = name;
 		this.variants = variants;
-		variantHolders.add(this);
 	}
 
+	@Nonnull
 	@Override
-	public Item setUnlocalizedName(String name) {
+	public Item setUnlocalizedName(@Nonnull String name) {
 		super.setUnlocalizedName(name);
 		setRegistryName(new ResourceLocation(getPrefix() + name));
 		ProxyRegistry.register(this);
@@ -54,6 +54,7 @@ public abstract class ItemMod extends Item implements IVariantHolder {
 		return this;
 	}
 
+	@Nonnull
 	@Override
 	public String getUnlocalizedName(ItemStack par1ItemStack) {
 		int dmg = par1ItemStack.getItemDamage();
@@ -68,7 +69,7 @@ public abstract class ItemMod extends Item implements IVariantHolder {
 	}
 
 	@Override
-	public void getSubItems(CreativeTabs tab, NonNullList<ItemStack> subItems) {
+	public void getSubItems(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> subItems) {
 		if(isInCreativeTab(tab))
 			for(int i = 0; i < getVariants().length; i++)
 				subItems.add(new ItemStack(this, 1, i));
@@ -77,11 +78,6 @@ public abstract class ItemMod extends Item implements IVariantHolder {
 	@Override
 	public String[] getVariants() {
 		return variants;
-	}
-
-	@Override
-	public ItemMeshDefinition getCustomMeshDefinition() {
-		return null;
 	}
 
 	@SideOnly(Side.CLIENT)

--- a/src/main/java/vazkii/arl/item/ItemModArmor.java
+++ b/src/main/java/vazkii/arl/item/ItemModArmor.java
@@ -10,7 +10,6 @@
  */
 package vazkii.arl.item;
 
-import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
@@ -19,6 +18,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import vazkii.arl.interf.IVariantHolder;
 import vazkii.arl.util.ProxyRegistry;
+
+import javax.annotation.Nonnull;
 
 public abstract class ItemModArmor extends ItemArmor implements IVariantHolder {
 
@@ -29,12 +30,12 @@ public abstract class ItemModArmor extends ItemArmor implements IVariantHolder {
 
 		setUnlocalizedName(name);
 		bareName = name;
-		ItemMod.variantHolders.add(this);
 		setCreativeTab(CreativeTabs.COMBAT);
 	}
 
+	@Nonnull
 	@Override
-	public Item setUnlocalizedName(String name) {
+	public Item setUnlocalizedName(@Nonnull String name) {
 		super.setUnlocalizedName(name);
 		setRegistryName(new ResourceLocation(getPrefix() + name));
 		ProxyRegistry.register(this);
@@ -42,6 +43,7 @@ public abstract class ItemModArmor extends ItemArmor implements IVariantHolder {
 		return this;
 	}
 
+	@Nonnull
 	@Override
 	public String getUnlocalizedName(ItemStack par1ItemStack) {
 		par1ItemStack.getItemDamage();
@@ -52,11 +54,6 @@ public abstract class ItemModArmor extends ItemArmor implements IVariantHolder {
 	@Override
 	public String[] getVariants() {
 		return new String[] { bareName };
-	}
-
-	@Override
-	public ItemMeshDefinition getCustomMeshDefinition() {
-		return null;
 	}
 
 }

--- a/src/main/java/vazkii/arl/item/ItemModBlock.java
+++ b/src/main/java/vazkii/arl/item/ItemModBlock.java
@@ -18,8 +18,12 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.arl.interf.IModBlock;
 import vazkii.arl.interf.IVariantHolder;
+
+import javax.annotation.Nonnull;
 
 public class ItemModBlock extends ItemBlock implements IVariantHolder {
 
@@ -29,7 +33,6 @@ public class ItemModBlock extends ItemBlock implements IVariantHolder {
 		super(block);
 		modBlock = (IModBlock) block;
 
-		ItemMod.variantHolders.add(this);
 		if(getVariants().length > 1)
 			setHasSubtypes(true);
 		setRegistryName(res);
@@ -40,11 +43,13 @@ public class ItemModBlock extends ItemBlock implements IVariantHolder {
 		return damage;
 	}
 
+	@Nonnull
 	@Override
-	public ItemBlock setUnlocalizedName(String par1Str) {
+	public ItemBlock setUnlocalizedName(@Nonnull String par1Str) {
 		return (ItemBlock) super.setUnlocalizedName(par1Str);
 	}
 
+	@Nonnull
 	@Override
 	public String getUnlocalizedName(ItemStack par1ItemStack) {
 		int dmg = par1ItemStack.getItemDamage();
@@ -59,7 +64,7 @@ public class ItemModBlock extends ItemBlock implements IVariantHolder {
 	}
 
 	@Override
-	public void getSubItems(CreativeTabs tab, NonNullList<ItemStack> subItems) {
+	public void getSubItems(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> subItems) {
 		String[] variants = getVariants();
 		if(isInCreativeTab(tab))
 			for(int i = 0; i < variants.length; i++)
@@ -73,10 +78,12 @@ public class ItemModBlock extends ItemBlock implements IVariantHolder {
 	}
 
 	@Override
+	@SideOnly(Side.CLIENT)
 	public ItemMeshDefinition getCustomMeshDefinition() {
 		return modBlock.getCustomMeshDefinition();
 	}
 
+	@Nonnull
 	@Override
 	public EnumRarity getRarity(ItemStack stack) {
 		return modBlock.getBlockRarity(stack);

--- a/src/main/java/vazkii/arl/item/ItemModBlockSlab.java
+++ b/src/main/java/vazkii/arl/item/ItemModBlockSlab.java
@@ -19,9 +19,13 @@ import net.minecraft.item.ItemSlab;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.arl.block.BlockModSlab;
 import vazkii.arl.interf.IModBlock;
 import vazkii.arl.interf.IVariantHolder;
+
+import javax.annotation.Nonnull;
 
 public class ItemModBlockSlab extends ItemSlab implements IVariantHolder {
 
@@ -31,7 +35,6 @@ public class ItemModBlockSlab extends ItemSlab implements IVariantHolder {
 		super(block, ((BlockModSlab) block).getSingleBlock(), ((BlockModSlab) block).getFullBlock());
 		modBlock = (IModBlock) block;
 
-		ItemMod.variantHolders.add(this);
 		if(getVariants().length > 1)
 			setHasSubtypes(true);
 		setRegistryName(res);
@@ -42,11 +45,13 @@ public class ItemModBlockSlab extends ItemSlab implements IVariantHolder {
 		return damage;
 	}
 
+	@Nonnull
 	@Override
-	public ItemBlock setUnlocalizedName(String par1Str) {
+	public ItemBlock setUnlocalizedName(@Nonnull String par1Str) {
 		return (ItemBlock) super.setUnlocalizedName(par1Str);
 	}
 
+	@Nonnull
 	@Override
 	public String getUnlocalizedName(ItemStack par1ItemStack) {
 		int dmg = par1ItemStack.getItemDamage();
@@ -61,7 +66,7 @@ public class ItemModBlockSlab extends ItemSlab implements IVariantHolder {
 	}
 
 	@Override
-	public void getSubItems(CreativeTabs tab, NonNullList<ItemStack> subItems) {
+	public void getSubItems(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> subItems) {
 		String[] variants = getVariants();
 		if(isInCreativeTab(tab))
 			for(int i = 0; i < variants.length; i++)
@@ -74,10 +79,12 @@ public class ItemModBlockSlab extends ItemSlab implements IVariantHolder {
 	}
 
 	@Override
+	@SideOnly(Side.CLIENT)
 	public ItemMeshDefinition getCustomMeshDefinition() {
 		return modBlock.getCustomMeshDefinition();
 	}
 
+	@Nonnull
 	@Override
 	public EnumRarity getRarity(ItemStack stack) {
 		return modBlock.getBlockRarity(stack);

--- a/src/main/java/vazkii/arl/item/ItemModSword.java
+++ b/src/main/java/vazkii/arl/item/ItemModSword.java
@@ -10,13 +10,14 @@
  */
 package vazkii.arl.item;
 
-import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemSword;
 import net.minecraft.util.ResourceLocation;
 import vazkii.arl.interf.IVariantHolder;
 import vazkii.arl.util.ProxyRegistry;
+
+import javax.annotation.Nonnull;
 
 public abstract class ItemModSword extends ItemSword implements IVariantHolder {
 
@@ -34,11 +35,11 @@ public abstract class ItemModSword extends ItemSword implements IVariantHolder {
 
 		bareName = name;
 		this.variants = variants;
-		ItemMod.variantHolders.add(this);
 	}
 
+	@Nonnull
 	@Override
-	public Item setUnlocalizedName(String name) {
+	public Item setUnlocalizedName(@Nonnull String name) {
 		super.setUnlocalizedName(name);
 		setRegistryName(new ResourceLocation(getPrefix() + name));
 		ProxyRegistry.register(this);
@@ -46,6 +47,7 @@ public abstract class ItemModSword extends ItemSword implements IVariantHolder {
 		return this;
 	}
 
+	@Nonnull
 	@Override
 	public String getUnlocalizedName(ItemStack par1ItemStack) {
 		int dmg = par1ItemStack.getItemDamage();
@@ -62,11 +64,6 @@ public abstract class ItemModSword extends ItemSword implements IVariantHolder {
 	@Override
 	public String[] getVariants() {
 		return variants;
-	}
-
-	@Override
-	public ItemMeshDefinition getCustomMeshDefinition() {
-		return null;
 	}
 
 }

--- a/src/main/java/vazkii/arl/item/ItemModTool.java
+++ b/src/main/java/vazkii/arl/item/ItemModTool.java
@@ -10,16 +10,16 @@
  */
 package vazkii.arl.item;
 
-import java.util.Set;
-
 import net.minecraft.block.Block;
-import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemTool;
 import net.minecraft.util.ResourceLocation;
 import vazkii.arl.interf.IVariantHolder;
 import vazkii.arl.util.ProxyRegistry;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
 
 public abstract class ItemModTool extends ItemTool implements IVariantHolder {
 
@@ -37,11 +37,11 @@ public abstract class ItemModTool extends ItemTool implements IVariantHolder {
 
 		bareName = name;
 		this.variants = variants;
-		ItemMod.variantHolders.add(this);
 	}
 
+	@Nonnull
 	@Override
-	public Item setUnlocalizedName(String name) {
+	public Item setUnlocalizedName(@Nonnull String name) {
 		super.setUnlocalizedName(name);
 		setRegistryName(new ResourceLocation(getPrefix() + name));
 		ProxyRegistry.register(this);
@@ -49,6 +49,7 @@ public abstract class ItemModTool extends ItemTool implements IVariantHolder {
 		return this;
 	}
 
+	@Nonnull
 	@Override
 	public String getUnlocalizedName(ItemStack par1ItemStack) {
 		int dmg = par1ItemStack.getItemDamage();
@@ -65,11 +66,6 @@ public abstract class ItemModTool extends ItemTool implements IVariantHolder {
 	@Override
 	public String[] getVariants() {
 		return variants;
-	}
-
-	@Override
-	public ItemMeshDefinition getCustomMeshDefinition() {
-		return null;
 	}
 
 }

--- a/src/main/java/vazkii/arl/item/ModelModArmor.java
+++ b/src/main/java/vazkii/arl/item/ModelModArmor.java
@@ -23,13 +23,15 @@ import net.minecraft.util.EnumHandSide;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import javax.annotation.Nonnull;
+
 @SideOnly(Side.CLIENT)
 public abstract class ModelModArmor extends ModelBiped {
 
 	public abstract void setModelParts();
 
 	@Override
-	public void render(Entity entity, float f, float f1, float f2, float f3, float f4, float f5) {
+	public void render(@Nonnull Entity entity, float f, float f1, float f2, float f3, float f4, float f5) {
 		setModelParts();
 
 		GlStateManager.pushMatrix();
@@ -45,9 +47,9 @@ public abstract class ModelModArmor extends ModelBiped {
 
 	public void prepareForRender(Entity entity, float pticks) {
 		EntityLivingBase living = (EntityLivingBase) entity;
-		isSneak = living != null ? living.isSneaking() : false;
-		isChild = living != null ? living.isChild() : false;
-		if(living != null && living instanceof EntityPlayer) {
+		isSneak = living != null && living.isSneaking();
+		isChild = living != null && living.isChild();
+		if(living instanceof EntityPlayer) {
 			EntityPlayer player = (EntityPlayer) living;
 
 			swingProgress = player.getSwingProgress(pticks);

--- a/src/main/java/vazkii/arl/network/NetworkHandler.java
+++ b/src/main/java/vazkii/arl/network/NetworkHandler.java
@@ -22,7 +22,7 @@ public class NetworkHandler {
 
 	private static int i = 0;
 
-	public static void register(Class clazz, Side handlerSide) {
+	public static <T extends NetworkMessage<T>> void register(Class<T> clazz, Side handlerSide) {
 		INSTANCE.registerMessage(clazz, clazz, i++, handlerSide);
 	}
 	

--- a/src/main/java/vazkii/arl/network/TileEntityMessage.java
+++ b/src/main/java/vazkii/arl/network/TileEntityMessage.java
@@ -30,16 +30,16 @@ public abstract class TileEntityMessage<T extends TileEntity> extends NetworkMes
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public final IMessage handleMessage(MessageContext context) {
 		this.context = context;
 		World world = context.getServerHandler().player.getEntityWorld();
 		TileEntity tile = world.getTileEntity(pos);
 		if(tile != null)
 			try {
-				T castTile = (T) tile;
-				this.tile = castTile;
+				this.tile = (T) tile;
 				((WorldServer) world).addScheduledTask(getAction());
-			} catch(ClassCastException e) { }
+			} catch(ClassCastException ignored) { }
 
 		return super.handleMessage(context);
 	}

--- a/src/main/java/vazkii/arl/network/message/MessageDropIn.java
+++ b/src/main/java/vazkii/arl/network/message/MessageDropIn.java
@@ -1,6 +1,6 @@
 package vazkii.arl.network.message;
 
-import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
@@ -25,8 +25,8 @@ public class MessageDropIn extends NetworkMessage<MessageDropIn> {
 	
 	@Override
 	public IMessage handleMessage(MessageContext context) {
-		EntityPlayer player = context.getServerHandler().player;
-		player.getServer().addScheduledTask(() -> DropInHandler.executeDropIn(player, slot, stack)); 
+		EntityPlayerMP player = context.getServerHandler().player;
+		player.mcServer.addScheduledTask(() -> DropInHandler.executeDropIn(player, slot, stack));
 		
 		return null;
 	}

--- a/src/main/java/vazkii/arl/recipe/BlacklistOreIngredient.java
+++ b/src/main/java/vazkii/arl/recipe/BlacklistOreIngredient.java
@@ -1,10 +1,5 @@
 package vazkii.arl.recipe;
 
-import java.util.function.Predicate;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntComparators;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -14,6 +9,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.oredict.OreDictionary;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.function.Predicate;
 
 // Basically a copy of OreIngredient with a blacklist
 public class BlacklistOreIngredient extends Ingredient {
@@ -46,7 +45,7 @@ public class BlacklistOreIngredient extends Ingredient {
 					lst.add(itemstack);
 			}
 			
-			this.array = lst.toArray(new ItemStack[lst.size()]);
+			this.array = lst.toArray(new ItemStack[0]);
 			this.lastSizeA = ores.size();
 		}
 		return this.array;

--- a/src/main/java/vazkii/arl/recipe/MultiRecipe.java
+++ b/src/main/java/vazkii/arl/recipe/MultiRecipe.java
@@ -1,17 +1,18 @@
 package vazkii.arl.recipe;
 
-import java.util.LinkedList;
-import java.util.List;
-
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 
+import javax.annotation.Nonnull;
+import java.util.LinkedList;
+import java.util.List;
+
 public class MultiRecipe extends ModRecipe {
 
-	private List<IRecipe> subRecipes = new LinkedList();
+	private List<IRecipe> subRecipes = new LinkedList<>();
 	IRecipe matched;
 	
 	public MultiRecipe(ResourceLocation res) {
@@ -23,7 +24,7 @@ public class MultiRecipe extends ModRecipe {
 	}
 
 	@Override
-	public boolean matches(InventoryCrafting inv, World worldIn) {
+	public boolean matches(@Nonnull InventoryCrafting inv, @Nonnull World worldIn) {
 		matched = null;
 		for(IRecipe recipe : subRecipes)
 			if(recipe.matches(inv, worldIn)) {
@@ -34,8 +35,9 @@ public class MultiRecipe extends ModRecipe {
 		return false;
 	}
 
+	@Nonnull
 	@Override
-	public ItemStack getCraftingResult(InventoryCrafting inv) {
+	public ItemStack getCraftingResult(@Nonnull InventoryCrafting inv) {
 		if(matched == null)
 			return ItemStack.EMPTY;
 		
@@ -47,6 +49,7 @@ public class MultiRecipe extends ModRecipe {
 		return false;
 	}
 
+	@Nonnull
 	@Override
 	public ItemStack getRecipeOutput() {
 		return ItemStack.EMPTY;

--- a/src/main/java/vazkii/arl/recipe/RecipeHandler.java
+++ b/src/main/java/vazkii/arl/recipe/RecipeHandler.java
@@ -10,18 +10,8 @@
  ******************************************************************************/
 package vazkii.arl.recipe;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
@@ -37,9 +27,12 @@ import net.minecraftforge.oredict.OreIngredient;
 import vazkii.arl.interf.IRecipeGrouped;
 import vazkii.arl.util.ProxyRegistry;
 
+import java.util.*;
+import java.util.stream.Collectors;
+
 public final class RecipeHandler {
 	
-	private static final List<ResourceLocation> usedNames = new ArrayList();
+	private static final List<ResourceLocation> usedNames = new ArrayList<>();
 	
 	// Many bridge methods for backwards compatibility
 	
@@ -116,8 +109,8 @@ public final class RecipeHandler {
 
 		try {
 			key.put(" ", Ingredient.EMPTY);
-			Object ingredients = prepareMaterials(pattern.toArray(new String[pattern.size()]), key, width, height);
-			ShapedRecipes recipe = new ShapedRecipes(outputGroup(namespace, output), width, height, (NonNullList<Ingredient>) ingredients, output);
+			NonNullList<Ingredient> ingredients = prepareMaterials(pattern.toArray(new String[0]), key, width, height);
+			ShapedRecipes recipe = new ShapedRecipes(outputGroup(namespace, output), width, height, ingredients, output);
 			if(multi != null)
 				multi.addRecipe(recipe);
 			else addRecipe(unusedLocForOutput(namespace, output), recipe);
@@ -129,15 +122,12 @@ public final class RecipeHandler {
 	// copy from vanilla
 	private static NonNullList<Ingredient> prepareMaterials(String[] p_192402_0_, Map<String, Ingredient> p_192402_1_, int p_192402_2_, int p_192402_3_) {
 		NonNullList<Ingredient> nonnulllist = NonNullList.<Ingredient>withSize(p_192402_2_ * p_192402_3_, Ingredient.EMPTY);
-		Set<String> set = Sets.newHashSet(p_192402_1_.keySet());
-		set.remove(" ");
 
 		for(int i = 0; i < p_192402_0_.length; ++i)
 			for (int j = 0; j < p_192402_0_[i].length(); ++j) {
 				String s = p_192402_0_[i].substring(j, j + 1);
 				Ingredient ingredient = p_192402_1_.get(s);
 
-				set.remove(s);
 				nonnulllist.set(j + p_192402_2_ * i, ingredient);
 			}
 
@@ -154,7 +144,7 @@ public final class RecipeHandler {
 	}
 	
 	public static Ingredient compound(Object... objects) {
-		List<Ingredient> ingredients = Arrays.asList(objects).stream().map(RecipeHandler::asIngredient).collect(Collectors.toList());
+		List<Ingredient> ingredients = Arrays.stream(objects).map(RecipeHandler::asIngredient).collect(Collectors.toList());
 		return new PublicCompoundIngredient(ingredients);
 	}
 
@@ -179,7 +169,7 @@ public final class RecipeHandler {
 	}
 
 	private static ResourceLocation unusedLocForOutput(String namespace, ItemStack output) {
-		ResourceLocation baseLoc = new ResourceLocation(namespace, output.getItem().getRegistryName().getResourcePath());
+		ResourceLocation baseLoc = new ResourceLocation(namespace, Objects.requireNonNull(output.getItem().getRegistryName()).getResourcePath());
 		ResourceLocation recipeLoc = baseLoc;
 		int index = 0;
 
@@ -202,11 +192,11 @@ public final class RecipeHandler {
 				return namespace + ":" + ((IRecipeGrouped) block).getRecipeGroup();
 		}
 
-		return output.getItem().getRegistryName().toString();
+		return Objects.requireNonNull(output.getItem().getRegistryName()).toString();
 	}
 	
 	private static String getNamespace() {
-		return Loader.instance().activeModContainer().getModId();
+		return Objects.requireNonNull(Loader.instance().activeModContainer()).getModId();
 	}
 
 

--- a/src/main/java/vazkii/arl/util/AbstractDropIn.java
+++ b/src/main/java/vazkii/arl/util/AbstractDropIn.java
@@ -1,21 +1,24 @@
 package vazkii.arl.util;
 
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import vazkii.arl.interf.IDropInItem;
 
+import javax.annotation.Nonnull;
+
 public abstract class AbstractDropIn implements ICapabilityProvider, IDropInItem {
 
 	@Override
-	public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
+	@SuppressWarnings("ConstantConditions")
+	public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing facing) {
 		return capability == DROP_IN_CAPABILITY;
 	}
 
 	@Override
-	public <T> T getCapability(Capability<T> capability, EnumFacing facing) {
-		return capability == DROP_IN_CAPABILITY ? (T) this : null;
+	@SuppressWarnings("ConstantConditions")
+	public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing facing) {
+		return capability == DROP_IN_CAPABILITY ? DROP_IN_CAPABILITY.cast(this) : null;
 	}
 
 }

--- a/src/main/java/vazkii/arl/util/ClientTicker.java
+++ b/src/main/java/vazkii/arl/util/ClientTicker.java
@@ -1,15 +1,21 @@
 package vazkii.arl.util;
 
-import java.util.ArrayDeque;
-import java.util.Queue;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
 import net.minecraftforge.fml.common.gameevent.TickEvent.RenderTickEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import vazkii.arl.AutoRegLib;
 
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+@SideOnly(Side.CLIENT)
+@Mod.EventBusSubscriber(value = Side.CLIENT, modid = AutoRegLib.MOD_ID)
 public final class ClientTicker {
 
 	public static int ticksInGame = 0;

--- a/src/main/java/vazkii/arl/util/DropInHandler.java
+++ b/src/main/java/vazkii/arl/util/DropInHandler.java
@@ -1,9 +1,5 @@
 package vazkii.arl.util;
 
-import java.util.concurrent.Callable;
-
-import org.lwjgl.input.Mouse;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -15,22 +11,29 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.client.event.GuiScreenEvent;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.lwjgl.input.Mouse;
+import vazkii.arl.AutoRegLib;
 import vazkii.arl.interf.IDropInItem;
 import vazkii.arl.network.NetworkHandler;
 import vazkii.arl.network.message.MessageDropIn;
 
+import java.util.concurrent.Callable;
+
+@Mod.EventBusSubscriber(value = Side.CLIENT, modid = AutoRegLib.MOD_ID)
 public final class DropInHandler {
 
 	public static void register() {
-		MinecraftForge.EVENT_BUS.register(DropInHandler.class);
 		CapabilityManager.INSTANCE.register(IDropInItem.class, CapabilityFactory.INSTANCE, CapabilityFactory.INSTANCE);
 	}
 	
 	@SubscribeEvent
+	@SideOnly(Side.CLIENT)
 	public static void onDrawScreen(GuiScreenEvent.DrawScreenEvent.Post event) {
 		Minecraft mc = Minecraft.getMinecraft();
 		GuiScreen gui = mc.currentScreen;
@@ -62,6 +65,7 @@ public final class DropInHandler {
 	}
 
 	@SubscribeEvent
+	@SideOnly(Side.CLIENT)
 	public static void onRightClick(GuiScreenEvent.MouseInputEvent.Pre event) {
 		Minecraft mc = Minecraft.getMinecraft();
 		GuiScreen gui = mc.currentScreen;
@@ -128,7 +132,7 @@ public final class DropInHandler {
 		}
 
 		@Override
-		public IDropInItem call() throws Exception {
+		public IDropInItem call() {
 			return new DefaultImpl();
 		}
 		

--- a/src/main/java/vazkii/arl/util/ItemNBTHelper.java
+++ b/src/main/java/vazkii/arl/util/ItemNBTHelper.java
@@ -87,50 +87,56 @@ public final class ItemNBTHelper {
 
 	// GETTERS ///////////////////////////////////////////////////////////////////
 
+
+	public static boolean verifyExistence(ItemStack stack, String tag) {
+		return !stack.isEmpty() && detectNBT(stack) && getNBT(stack).hasKey(tag);
+	}
+
+	@Deprecated
 	public static boolean verifyExistance(ItemStack stack, String tag) {
-		return !stack.isEmpty() && getNBT(stack).hasKey(tag);
+		return verifyExistence(stack, tag);
 	}
 
 	public static boolean getBoolean(ItemStack stack, String tag, boolean defaultExpected) {
-		return verifyExistance(stack, tag) ? getNBT(stack).getBoolean(tag) : defaultExpected;
+		return verifyExistence(stack, tag) ? getNBT(stack).getBoolean(tag) : defaultExpected;
 	}
 
 	public static byte getByte(ItemStack stack, String tag, byte defaultExpected) {
-		return verifyExistance(stack, tag) ? getNBT(stack).getByte(tag) : defaultExpected;
+		return verifyExistence(stack, tag) ? getNBT(stack).getByte(tag) : defaultExpected;
 	}
 
 	public static short getShort(ItemStack stack, String tag, short defaultExpected) {
-		return verifyExistance(stack, tag) ? getNBT(stack).getShort(tag) : defaultExpected;
+		return verifyExistence(stack, tag) ? getNBT(stack).getShort(tag) : defaultExpected;
 	}
 
 	public static int getInt(ItemStack stack, String tag, int defaultExpected) {
-		return verifyExistance(stack, tag) ? getNBT(stack).getInteger(tag) : defaultExpected;
+		return verifyExistence(stack, tag) ? getNBT(stack).getInteger(tag) : defaultExpected;
 	}
 
 	public static long getLong(ItemStack stack, String tag, long defaultExpected) {
-		return verifyExistance(stack, tag) ? getNBT(stack).getLong(tag) : defaultExpected;
+		return verifyExistence(stack, tag) ? getNBT(stack).getLong(tag) : defaultExpected;
 	}
 
 	public static float getFloat(ItemStack stack, String tag, float defaultExpected) {
-		return verifyExistance(stack, tag) ? getNBT(stack).getFloat(tag) : defaultExpected;
+		return verifyExistence(stack, tag) ? getNBT(stack).getFloat(tag) : defaultExpected;
 	}
 
 	public static double getDouble(ItemStack stack, String tag, double defaultExpected) {
-		return verifyExistance(stack, tag) ? getNBT(stack).getDouble(tag) : defaultExpected;
+		return verifyExistence(stack, tag) ? getNBT(stack).getDouble(tag) : defaultExpected;
 	}
 
 	/** If nullifyOnFail is true it'll return null if it doesn't find any
 	 * compounds, otherwise it'll return a new one. **/
 	public static NBTTagCompound getCompound(ItemStack stack, String tag, boolean nullifyOnFail) {
-		return verifyExistance(stack, tag) ? getNBT(stack).getCompoundTag(tag) : nullifyOnFail ? null : new NBTTagCompound();
+		return verifyExistence(stack, tag) ? getNBT(stack).getCompoundTag(tag) : nullifyOnFail ? null : new NBTTagCompound();
 	}
 
 	public static String getString(ItemStack stack, String tag, String defaultExpected) {
-		return verifyExistance(stack, tag) ? getNBT(stack).getString(tag) : defaultExpected;
+		return verifyExistence(stack, tag) ? getNBT(stack).getString(tag) : defaultExpected;
 	}
 
 	public static NBTTagList getList(ItemStack stack, String tag, int objtype, boolean nullifyOnFail) {
-		return verifyExistance(stack, tag) ? getNBT(stack).getTagList(tag, objtype) : nullifyOnFail ? null : new NBTTagList();
+		return verifyExistence(stack, tag) ? getNBT(stack).getTagList(tag, objtype) : nullifyOnFail ? null : new NBTTagList();
 	}
 
 }

--- a/src/main/java/vazkii/arl/util/ModelHandler.java
+++ b/src/main/java/vazkii/arl/util/ModelHandler.java
@@ -10,35 +10,37 @@
  */
 package vazkii.arl.util;
 
-import java.util.HashMap;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.properties.IProperty;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.block.statemap.IStateMapper;
 import net.minecraft.client.renderer.block.statemap.StateMap;
-import net.minecraft.client.renderer.color.BlockColors;
-import net.minecraft.client.renderer.color.ItemColors;
+import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IStringSerializable;
+import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import vazkii.arl.interf.IBlockColorProvider;
-import vazkii.arl.interf.IExtraVariantHolder;
-import vazkii.arl.interf.IItemColorProvider;
-import vazkii.arl.interf.IModBlock;
-import vazkii.arl.interf.IVariantHolder;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import vazkii.arl.AutoRegLib;
+import vazkii.arl.interf.*;
 import vazkii.arl.item.ItemMod;
 
+import java.util.HashMap;
+import java.util.Objects;
+
+@SideOnly(Side.CLIENT)
+@Mod.EventBusSubscriber(value = Side.CLIENT, modid = AutoRegLib.MOD_ID)
 public final class ModelHandler {
 
-	public static final HashMap<String, ModelResourceLocation> resourceLocations = new HashMap();
+	public static final HashMap<String, ModelResourceLocation> resourceLocations = new HashMap<>();
 
 	@SubscribeEvent
 	public static void onRegister(ModelRegistryEvent event) {
@@ -46,66 +48,99 @@ public final class ModelHandler {
 			registerModels(holder);
 	}
 
-	public static void init() {
-		ItemColors itemColors = Minecraft.getMinecraft().getItemColors();
-		BlockColors blockColors = Minecraft.getMinecraft().getBlockColors();
+	@SubscribeEvent
+	public static void onItemColorRegister(ColorHandlerEvent.Item event) {
+		for(IVariantHolder holder : ItemMod.variantHolders)
+			if (holder instanceof IItemColorProvider) {
 
-		for(IVariantHolder holder : ItemMod.variantHolders) {
-			if(holder instanceof IItemColorProvider)
-				itemColors.registerItemColorHandler(((IItemColorProvider) holder).getItemColor(), (Item) holder);
+				Item item;
+				if (holder instanceof Block)
+					item = Item.getItemFromBlock((Block) holder);
+				else if (holder instanceof Item)
+					item = (Item) holder;
+				else
+					continue;
 
-			if(holder instanceof ItemBlock && ((ItemBlock) holder).getBlock() instanceof IBlockColorProvider) {
-				Block block = ((ItemBlock) holder).getBlock();
-				blockColors.registerBlockColorHandler(((IBlockColorProvider) block).getBlockColor(), block);
-				itemColors.registerItemColorHandler(((IBlockColorProvider) block).getItemColor(), block);
+				if (item == Items.AIR)
+					continue;
+
+				event.getItemColors().registerItemColorHandler(((IItemColorProvider) holder).getItemColor(), item);
 			}
-		}
+	}
+
+	@SubscribeEvent
+	public static void onBlockColorRegister(ColorHandlerEvent.Block event) {
+		for(IVariantHolder holder : ItemMod.variantHolders)
+			if (holder instanceof IBlockColorProvider) {
+				Block block;
+				if (holder instanceof ItemBlock)
+					block = ((ItemBlock) holder).getBlock();
+				else if (holder instanceof Block)
+					block = (Block) holder;
+				else
+					continue;
+
+				event.getBlockColors().registerBlockColorHandler(((IBlockColorProvider) block).getBlockColor(), block);
+			}
 	}
 
 	public static void registerModels(IVariantHolder holder) {
-		String unique = holder.getUniqueModel();
-		String prefix = holder.getPrefix();
-		Item i = (Item) holder;
+		if (holder instanceof Item) {
+			String unique = holder.getUniqueModel();
+			String prefix = holder.getPrefix();
+			Item i = (Item) holder;
 
-		ItemMeshDefinition def = holder.getCustomMeshDefinition();
-		if(def != null)
-			ModelLoader.setCustomMeshDefinition((Item) holder, def);
-		else registerModels(i, prefix, holder.getVariants(), unique, false);
+			ItemMeshDefinition def = holder.getCustomMeshDefinition();
+			if (def != null)
+				ModelLoader.setCustomMeshDefinition((Item) holder, def);
+			else registerModels(i, prefix, holder.getVariants(), unique, false);
 
-		if(holder instanceof IExtraVariantHolder) {
-			IExtraVariantHolder extra = (IExtraVariantHolder) holder;
-			registerModels(i, prefix, extra.getExtraVariants(), unique, true);
+
+			if (holder instanceof IExtraVariantHolder) {
+				IExtraVariantHolder extra = (IExtraVariantHolder) holder;
+				registerModels(i, prefix, extra.getExtraVariants(), unique, true);
+			}
+		} else if (holder instanceof Block) {
+			// Set IStateMapper for blocks without items.
+			registerBlock((Block) holder);
 		}
 	}
 
+	public static void registerBlock(Block block) {
+		IModBlock quarkBlock = (IModBlock) block;
+		IProperty variantProp = quarkBlock.getVariantProp();
+
+		IStateMapper mapper = quarkBlock.getStateMapper();
+		IProperty[] ignored = quarkBlock.getIgnoredProperties();
+		if(mapper != null || ignored != null && ignored.length > 0) {
+			if(mapper != null)
+				ModelLoader.setCustomStateMapper(block, mapper);
+			else
+				ModelLoader.setCustomStateMapper(block, new StateMap.Builder().ignore(ignored).build());
+		}
+	}
+
+	@SuppressWarnings("unchecked")
 	public static void registerModels(Item item, String prefix, String[] variants, String uniqueVariant, boolean extra) {
 		if(item instanceof ItemBlock && ((ItemBlock) item).getBlock() instanceof IModBlock) {
 			IModBlock quarkBlock = (IModBlock) ((ItemBlock) item).getBlock();
 			Class clazz = quarkBlock.getVariantEnum();
 
-			IProperty variantProp = quarkBlock.getVariantProp();
-			boolean ignoresVariant = false;
+			if (clazz != null) {
+				IProperty variantProp = quarkBlock.getVariantProp();
 
-			IStateMapper mapper = quarkBlock.getStateMapper();
-			IProperty[] ignored = quarkBlock.getIgnoredProperties();
-			if(mapper != null || ignored != null && ignored.length > 0) {
-				if(mapper != null)
-					ModelLoader.setCustomStateMapper((Block) quarkBlock, mapper);
-				else {
-					StateMap.Builder builder = new StateMap.Builder();
-					for(IProperty p : ignored) {
-						if(p == variantProp)
-							ignoresVariant = true;
-						builder.ignore(p);
+				IStateMapper mapper = quarkBlock.getStateMapper();
+				IProperty[] ignored = quarkBlock.getIgnoredProperties();
+				if (mapper != null || ignored != null && ignored.length > 0) {
+					if (mapper == null) {
+						for (IProperty p : ignored) {
+							if (p == variantProp) {
+								registerVariantsDefaulted(item, (Block) quarkBlock, clazz, variantProp.getName());
+								return;
+							}
+						}
 					}
-
-					ModelLoader.setCustomStateMapper((Block) quarkBlock, builder.build());
 				}
-			}
-
-			if(clazz != null && !ignoresVariant) {
-				registerVariantsDefaulted(item, (Block) quarkBlock, clazz, variantProp.getName());
-				return;
 			}
 		}
 
@@ -127,7 +162,7 @@ public final class ModelHandler {
 	}
 
 	private static <T extends Enum<T> & IStringSerializable> void registerVariantsDefaulted(Item item, Block b, Class<T> enumclazz, String variantHeader) {
-		String baseName = b.getRegistryName().toString();
+		String baseName = Objects.requireNonNull(b.getRegistryName()).toString();
 		for(T e : enumclazz.getEnumConstants()) {
 			String variantName = variantHeader + "=" + e.getName();
 			ModelResourceLocation loc = new ModelResourceLocation(baseName, variantName);

--- a/src/main/java/vazkii/arl/util/ProxyRegistry.java
+++ b/src/main/java/vazkii/arl/util/ProxyRegistry.java
@@ -1,29 +1,39 @@
 package vazkii.arl.util;
 
-import java.util.Collection;
-import java.util.HashMap;
-
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
-
 import net.minecraft.block.Block;
-import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.registries.IForgeRegistryEntry;
+import vazkii.arl.AutoRegLib;
+import vazkii.arl.interf.IVariantHolder;
+import vazkii.arl.item.ItemMod;
 
+import java.util.Collection;
+import java.util.HashMap;
+
+@Mod.EventBusSubscriber(modid = AutoRegLib.MOD_ID)
 public class ProxyRegistry {
 	
+	@SuppressWarnings("UnstableApiUsage")
 	private static Multimap<Class<?>, IForgeRegistryEntry<?>> entries = MultimapBuilder.hashKeys().arrayListValues().build();
 
-	private static HashMap<Block, Item> temporaryItemBlockMap = new HashMap();
+	private static HashMap<Block, Item> temporaryItemBlockMap = new HashMap<>();
 	
 	public static <T extends IForgeRegistryEntry<T>> void register(IForgeRegistryEntry<T> obj) {
+		if (obj == null)
+			return;
+
 		entries.put(obj.getRegistryType(), obj);
+
+		if (obj instanceof IVariantHolder)
+			ItemMod.variantHolders.add((IVariantHolder) obj);
 		
 		if(obj instanceof ItemBlock) {
 			ItemBlock iblock = (ItemBlock) obj;
@@ -34,7 +44,7 @@ public class ProxyRegistry {
 	
 	public static Item getItemMapping(Block block) {
 		Item i = Item.getItemFromBlock(block);
-		if((i == null || i == Item.getItemFromBlock(Blocks.AIR)) && temporaryItemBlockMap.containsKey(block))
+		if(i == Items.AIR && temporaryItemBlockMap.containsKey(block))
 			return temporaryItemBlockMap.get(block);
 		
 		return i;
@@ -63,8 +73,9 @@ public class ProxyRegistry {
 	public static ItemStack newStack(Item item, int size, int meta) {
 		return new ItemStack(item, size, meta);
 	}
-	
+
 	@SubscribeEvent
+	@SuppressWarnings("unchecked")
 	public static void onRegistryEvent(RegistryEvent.Register event) {
 		Class<?> type = event.getRegistry().getRegistrySuperType();
 		

--- a/src/main/java/vazkii/arl/util/TooltipHandler.java
+++ b/src/main/java/vazkii/arl/util/TooltipHandler.java
@@ -10,12 +10,12 @@
  */
 package vazkii.arl.util;
 
-import java.util.List;
-
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
+import java.util.List;
 
 public final class TooltipHandler {
 
@@ -34,7 +34,7 @@ public final class TooltipHandler {
 		for(int i = 0; i < format.length; i++)
 			formatVals[i] = local(format[i].toString()).replaceAll("&", "\u00a7");
 
-		if(formatVals != null && formatVals.length > 0)
+		if(formatVals.length > 0)
 			s = String.format(s, formatVals);
 
 		tooltip.add(s);


### PR DESCRIPTION
Clarify unclear generics
SideOnly all SideOnly classes and references that were previously unannotated
Fix nullability mismatches with annotations (Closes #18)
Make ARL respect (and permit) blocks with no items
Blocks with mesh definitions on their items have their statemappers registered
Use event handlers for color registration
Use @Mod.EventBusSubscriber for events, rather than manual registration

This has binary compatibility with most implementors. The only ones which would fail are those depending on the (removed) ModelHandler#init method, which would have caused issues if another mod invoked it, meaning that all mods which worked with ARL will continue to do so.