### PR TITLE
Avoid regex pattern overhead.

### DIFF
--- a/src/main/java/vazkii/arl/util/TooltipHandler.java
+++ b/src/main/java/vazkii/arl/util/TooltipHandler.java
@@ -28,11 +28,11 @@ public final class TooltipHandler {
 
 	@OnlyIn(Dist.CLIENT)
 	public static void addToTooltip(List<String> tooltip, String s, Object... format) {
-		s = I18n.get(s).replaceAll("&", "\u00a7");
+		s = I18n.get(s).replace("&", "\u00a7");
 
 		Object[] formatVals = new String[format.length];
 		for(int i = 0; i < format.length; i++)
-			formatVals[i] = I18n.get(format[i].toString()).replaceAll("&", "\u00a7");
+			formatVals[i] = I18n.get(format[i].toString()).replace("&", "\u00a7");
 
 		if(formatVals.length > 0)
 			s = String.format(s, formatVals);


### PR DESCRIPTION
This PR simply replaces the use of `String::replaceAll` with `String::replace` in the code that turns `&` in your tooltips into `§`. Both methods will replace all occurrences within the given string, however `String::replaceAll` is specifically for regex patterns and has a very small overhead as it compiles a new regex pattern each time. 